### PR TITLE
Add filter `itemsList_from_navigationFilter` (simpler version of `itemsList_from_navigationItemsFilter`).

### DIFF
--- a/src/rendering/createRenderer.js
+++ b/src/rendering/createRenderer.js
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 import nunjucks from "nunjucks";
 
 import dateFilter from "./filters/dateFilter.js";
+import itemsList_from_navigationFilter from "./filters/itemsList_from_navigationFilter.js";
 import itemsList_from_navigationItemsFilter from "./filters/itemsList_from_navigationItemsFilter.js";
 import createLocalizeFilter from "./filters/localizeFilter.js";
 import setPropertyFilter from "./filters/setPropertyFilter.js";
@@ -22,6 +23,7 @@ export default async function createRenderer(templatesPath, data, setupNunjucks 
   const nunjucksEnvironment = new nunjucks.Environment(nunjucksLoader);
 
   nunjucksEnvironment.addFilter("date", dateFilter);
+  nunjucksEnvironment.addFilter("itemsList_from_navigation", itemsList_from_navigationFilter);
   nunjucksEnvironment.addFilter("itemsList_from_navigationItems", itemsList_from_navigationItemsFilter);
   nunjucksEnvironment.addFilter("localize", createLocalizeFilter(data.site, data.stringsByLanguage));
   nunjucksEnvironment.addFilter("setProperty", setPropertyFilter);

--- a/src/rendering/createRenderer.spec.js
+++ b/src/rendering/createRenderer.spec.js
@@ -80,6 +80,14 @@ describe("createRenderer()", () => {
       .not.toThrow();
   });
 
+  it("adds the custom 'itemsList_from_navigation' filter", async () => {
+    const renderer = await createRenderer("tests/examples/templates", {});
+
+    await expect(renderer.renderString("{{ [] | itemsList_from_navigation }}"))
+      .resolves
+      .not.toThrow();
+  });
+
   it("adds the custom 'itemsList_from_navigationItems' filter", async () => {
     const renderer = await createRenderer("tests/examples/templates", {});
 

--- a/src/rendering/filters/itemsList_from_navigationFilter.js
+++ b/src/rendering/filters/itemsList_from_navigationFilter.js
@@ -1,0 +1,17 @@
+export default function itemsList_from_navigationFilter(navigation) {
+  if (!navigation) {
+    return [];
+  }
+
+  // Note: "text" and "title" are both required since the design system is inconsistent
+  // with usage in "itemsList" implementations.
+  return navigation
+    .map(item => ({
+      text: item?.navigationTitle,
+      title: item?.navigationTitle,
+      url: item?.url,
+      ariaLabel: item?.navigationTitle !== item?.title
+        ? (item?.title ?? null)
+        : null,
+    }));
+}

--- a/src/rendering/filters/itemsList_from_navigationFilter.spec.js
+++ b/src/rendering/filters/itemsList_from_navigationFilter.spec.js
@@ -1,0 +1,75 @@
+import itemsList_from_navigationFilter from "./itemsList_from_navigationFilter.js";
+
+const EXAMPLE_TEMPLATE_CONTEXT = {
+  getVariables() {
+    return {
+      site: {
+        baseUrl: "https://example.com/",
+      },
+    };
+  },
+};
+
+const EXAMPLE_ENTRY_ITEM = {
+  url: "/data-security",
+  navigationTitle: "Data security",
+};
+
+const EXAMPLE_ENTRY_ITEM_WITH_MATCHING_TITLE = {
+  url: "/data-security",
+  title: "Data security",
+  navigationTitle: "Data security",
+};
+
+const EXAMPLE_ENTRY_ITEM_WITH_DIFFERENT_TITLE = {
+  url: "/data-security",
+  title: "Keeping data secure",
+  navigationTitle: "Data security",
+};
+
+describe("itemsList_from_navigationFilter(navigationItems)", () => {
+  it("returns expected `itemsList` for entry item", () => {
+    const itemsList = itemsList_from_navigationFilter.call(EXAMPLE_TEMPLATE_CONTEXT, [
+      EXAMPLE_ENTRY_ITEM,
+    ]);
+
+    expect(itemsList).toEqual([
+      {
+        text: "Data security",
+        title: "Data security",
+        url: "/data-security",
+        ariaLabel: null,
+      },
+    ]);
+  });
+
+  it("returns expected `itemsList` for entry item where a `navigationTitle` is present and matches `title`", () => {
+    const itemsList = itemsList_from_navigationFilter.call(EXAMPLE_TEMPLATE_CONTEXT, [
+      EXAMPLE_ENTRY_ITEM_WITH_MATCHING_TITLE,
+    ]);
+
+    expect(itemsList).toEqual([
+      {
+        text: "Data security",
+        title: "Data security",
+        url: "/data-security",
+        ariaLabel: null,
+      },
+    ]);
+  });
+
+  it("returns expected `itemsList` for entry item where a `navigationTitle` is present and is different from `title`", () => {
+    const itemsList = itemsList_from_navigationFilter.call(EXAMPLE_TEMPLATE_CONTEXT, [
+      EXAMPLE_ENTRY_ITEM_WITH_DIFFERENT_TITLE,
+    ]);
+
+    expect(itemsList).toEqual([
+      {
+        text: "Data security",
+        title: "Data security",
+        url: "/data-security",
+        ariaLabel: "Keeping data secure",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
This filter is useful in situations where a list of entries are provided for a navigation list.

This differs from `itemsList_from_navigationItemsFilter` which operates on specialised navigation entries.