### PR TITLE
Support usage of the ONS design system via GitHub as well as npm.

### DIFF
--- a/src/rendering/createRenderer.js
+++ b/src/rendering/createRenderer.js
@@ -9,7 +9,13 @@ import setPropertyFilter from "./filters/setPropertyFilter.js";
 import uniqueIdFilter from "./filters/uniqueIdFilter.js";
 
 const designSystemPath = `${ process.cwd() }/node_modules/@ons/design-system`;
-const designSystemVersion = fs.readJsonSync(`${designSystemPath}/package.json`).version;
+
+let designSystemVersion = fs.readJsonSync(`${designSystemPath}/package.json`).version;
+if (designSystemVersion === "3.0.1") {
+  const projectPackageJson = fs.readJsonSync(`${process.cwd()}/package.json`, { encoding: "utf8" });
+  const designSystemDependency = projectPackageJson.dependencies["@ons/design-system"];
+  designSystemVersion = designSystemDependency.match(/#(\d+\.\d+\.\d+)$/)[1];
+}
 
 nunjucks.configure(null, {
   watch: false,
@@ -17,7 +23,7 @@ nunjucks.configure(null, {
 });
 
 export default async function createRenderer(templatesPath, data, setupNunjucks = null) {
-  const searchPaths = [ templatesPath, `${designSystemPath}` ];
+  const searchPaths = [ templatesPath, `${designSystemPath}`, `${designSystemPath}/src` ];
 
   const nunjucksLoader = new nunjucks.FileSystemLoader(searchPaths);
   const nunjucksEnvironment = new nunjucks.Environment(nunjucksLoader);


### PR DESCRIPTION
When the design system version is "3.0.1" it indicates that the version from GitHub is being used since that version number is not incremented when releases are made.

In this situation the version can be pulled from the git dependency. In addition we look for templates in the "src/" directory of the design system to support the GitHub version.