### PR TITLE
Decorate external links and tables with ONS design system classes

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -67,9 +67,11 @@ Accessing some value from a custom content source:
 
 The following custom filters have been defined for use in templates:
 
-- `localize(context = "main")` - Allows strings to be automatically localized when a localized string is defined; eg. `"Table of contents" | localize`. A language context can be provided for situations where there would be ambiguity, eg. `"Add" | localize("maths")`.
-
 - `date(format, locale = "en-gb")` - Formats a date using [moment.js](https://momentjs.com/).
+
+- `htmlContent` - Corrects internal URLs and decorates elements with ONS design system classes. This is useful for blobs of HTML content (eg. that from a WYSIWYG field). eg. `block.text | htmlContent | safe`.
+
+- `localize(context = "main")` - Allows strings to be automatically localized when a localized string is defined; eg. `"Table of contents" | localize`. A language context can be provided for situations where there would be ambiguity, eg. `"Add" | localize("maths")`.
 
 - `setProperty(key, value)` - Adds a property to an object which is useful in situations where properties need to be conditionally provided to a design system component. eg.
   ```nunjucks

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -71,6 +71,8 @@ The following custom filters have been defined for use in templates:
 
 - `htmlContent` - Corrects internal URLs and decorates elements with ONS design system classes. This is useful for blobs of HTML content (eg. that from a WYSIWYG field). eg. `block.text | htmlContent | safe`.
 
+- `itemsList_from_navigation` - Produces an array of items for use with ONS design system navigation components and lists. This uses the `navigationTitle`, `title` and `url` of provided entries to resolve navigation items.
+
 - `localize(context = "main")` - Allows strings to be automatically localized when a localized string is defined; eg. `"Table of contents" | localize`. A language context can be provided for situations where there would be ambiguity, eg. `"Add" | localize("maths")`.
 
 - `setProperty(key, value)` - Adds a property to an object which is useful in situations where properties need to be conditionally provided to a design system component. eg.
@@ -82,3 +84,5 @@ The following custom filters have been defined for use in templates:
       {% set options = options | setProperty("second", "Second option") %}
   {% endif %}
   ```
+
+- `uniqueId(base)` - Produces a unique identifier so that HTML elements can reference one another. For example, a variable can be defined with `{% set id = "foo" | uniqueId %}` which can then be used with multiple elements `<input id="{{ id }}"/>` and `<label for="{{ id }}">Example field</label>`.

--- a/src/Generator.js
+++ b/src/Generator.js
@@ -27,6 +27,8 @@ export default class Generator {
 
     try {
       const processedSites = Object.fromEntries(await Promise.all(this.sites.map(async site => {
+        site.templatesPath = site.templatesPath ?? this.defaultTemplatesPath;
+
         logger.stage(`Fetching data for site "${site.name}"...`);
         const data = await fetchSiteData(site, this.sitesByName);
 
@@ -58,8 +60,7 @@ export default class Generator {
   
       for (let processedSite of Object.values(processedSites)) {
         logger.stage(`Rendering and writing pages for site "${processedSite.name}"...`);
-        const templatesPath = processedSite.templatesPath ?? this.defaultTemplatesPath;
-        const renderer = await createRenderer(templatesPath, processedSite.data, processedSite.hooks?.setupNunjucks);
+        const renderer = await createRenderer(processedSite.data, processedSite.hooks?.setupNunjucks);
 
         const siteOutputPath = `${outputPath}/${processedSite.name}`;
         await renderSitePages(siteOutputPath, processedSite, renderer, this.writePage);

--- a/src/helpers/createStringReplacer.js
+++ b/src/helpers/createStringReplacer.js
@@ -1,5 +1,5 @@
 export default function createStringReplacer(replacements) {
-  const patterns = Object.keys(replacements);
+  const patterns = Object.keys(replacements).filter(key => key !== "");
 
   let replacementsPattern = "";
   for (let i = 0; i < patterns.length; ++i) {

--- a/src/helpers/createStringReplacer.spec.js
+++ b/src/helpers/createStringReplacer.spec.js
@@ -22,4 +22,16 @@ describe("createStringReplacer(replacements)", () => {
 
     expect(result).toBe("72 bar 14");
   });
+
+  it("ignores empty keys", () => {
+    const replacer = createStringReplacer({
+      "abc": "foo",
+      "": "bar",
+      "": "qux",
+    });
+
+    const result = replacer("abcd abc def");
+
+    expect(result).toBe("food foo def");
+  });
 });

--- a/src/helpers/resolveUrl.js
+++ b/src/helpers/resolveUrl.js
@@ -1,3 +1,15 @@
-export default function resolveUrl(url, context) {
-  return url.replace("/@root/", context.site.baseUrl);
+export default function resolveUrl(url, { site, cms }) {
+  // Resolve external resources for when using the CMS data source.
+  url = url.replace(/^(https?:[/])?[/][a-z0-9_/.:-]*external-resource[/](\d+)/, (_, prototcol, externalRef) => {
+    return cms?.getEntryById(externalRef)?.url;
+  });
+
+  // GraphQL responses from Craft often include URLs relative to the API domain.
+  // These need to be rebased onto the site's base URL.
+  if ((site.craftBaseUrl ?? "").startsWith("http")) {
+    url = url.replace(site.craftBaseUrl, site.baseUrl);
+  }
+
+  // Replace '/@root/' placeholder with the site's base URL.
+  return url.replace("/@root/", site.baseUrl);
 }

--- a/src/rendering/createRenderer.js
+++ b/src/rendering/createRenderer.js
@@ -1,10 +1,11 @@
 import fs from "fs-extra";
 import nunjucks from "nunjucks";
 
+import createHtmlContentFilter from "./filters/htmlContentFilter.js";
+import createLocalizeFilter from "./filters/localizeFilter.js";
 import dateFilter from "./filters/dateFilter.js";
 import itemsList_from_navigationFilter from "./filters/itemsList_from_navigationFilter.js";
 import itemsList_from_navigationItemsFilter from "./filters/itemsList_from_navigationItemsFilter.js";
-import createLocalizeFilter from "./filters/localizeFilter.js";
 import setPropertyFilter from "./filters/setPropertyFilter.js";
 import uniqueIdFilter from "./filters/uniqueIdFilter.js";
 
@@ -23,8 +24,8 @@ nunjucks.configure(null, {
   autoescape: true
 });
 
-export default async function createRenderer(templatesPath, data, setupNunjucks = null) {
-  const searchPaths = [ templatesPath, `${designSystemPath}`, `${designSystemPath}/src` ];
+export default async function createRenderer(data, setupNunjucks = null) {
+  const searchPaths = [ data.site.templatesPath, `${designSystemPath}`, `${designSystemPath}/src` ];
 
   const nunjucksLoader = new nunjucks.FileSystemLoader(searchPaths);
   const nunjucksEnvironment = new nunjucks.Environment(nunjucksLoader);
@@ -34,6 +35,7 @@ export default async function createRenderer(templatesPath, data, setupNunjucks 
   nunjucksEnvironment.addGlobal("designSystemCdnUrl", designSystemCdnBaseUrl + designSystemVersion);
 
   nunjucksEnvironment.addFilter("date", dateFilter);
+  nunjucksEnvironment.addFilter("htmlContent", createHtmlContentFilter(data));
   nunjucksEnvironment.addFilter("itemsList_from_navigation", itemsList_from_navigationFilter);
   nunjucksEnvironment.addFilter("itemsList_from_navigationItems", itemsList_from_navigationItemsFilter);
   nunjucksEnvironment.addFilter("localize", createLocalizeFilter(data.site, data.stringsByLanguage));

--- a/src/rendering/filters/htmlContentFilter.js
+++ b/src/rendering/filters/htmlContentFilter.js
@@ -1,0 +1,54 @@
+import createStringReplacer from "../../helpers/createStringReplacer.js";
+import escape from "../../helpers/escapeStringForRegExp.js";
+import resolveUrl from "../../helpers/resolveUrl.js";
+
+export default function createHtmlContentFilter(data) {
+  const internalUrls = [
+    "/",
+    data.site.baseUrl ?? "",
+    data.site.absoluteBaseUrl ?? "",
+    data.site.craftBaseUrl ?? "",
+  ].filter(url => url !== "");
+
+  const internalUrlPattern = new RegExp(`^(${internalUrls.map(escape).join("|")})`);
+
+  const htmlFixer = createStringReplacer({
+    // Process links.
+    "(?<link>[<]a(?<linkAttributes>[^>]+)[>](?<linkText>[^]+?)[<][/]a[>])": (groups) => {
+      const href = resolveUrl(groups.linkAttributes.match(/href="([^"]+)"/)?.[1], data);
+      let target = groups.linkAttributes.match(/target="([^"]+)"/)?.[1];
+
+      const isInternalLink = internalUrlPattern.test(href);
+      if (!isInternalLink && !target) {
+        target = "_blank";
+      }
+
+      if (target === "_blank") {
+        const classNames = groups.linkAttributes.match(/class="([^"]+)"/)?.[1] ?? "";
+        const otherAttributes = groups.linkAttributes.replace(/\s+(href|target|rel|class)="[^"]+"/g, "");
+
+        return `<a href="${href}" class="ons-external-link ${classNames}" target="_blank" rel="noopener"${otherAttributes}>
+          <span class="ons-external-link__text">${groups.linkText}</span><span class="ons-external-link__icon">&nbsp;<svg class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+            <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
+            <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
+          </svg></span><span class="ons-external-link__new-window-description ons-u-vh"> (opens in a new tab)</span></a>`;
+      }
+      else {
+        const otherAttributes = groups.linkAttributes.replace(/\s+(href)="[^"]+"/g, "");
+        return `<a href="${href}"${otherAttributes}>${groups.linkText}</a>`;
+      }
+    },
+
+    // Decorate table elements with ONS design system classes.
+    [escape("<table>")]: '<table class="ons-table ons-table--scrollable">',
+    [escape("<thead>")]: '<thead class="ons-table__head">',
+    [escape("<tbody>")]: '<tbody class="ons-table__body">',
+    [escape("<tr>")]: '<tr class="ons-table__row">',
+    [escape("<th>")]: '<th class="ons-table__header" scope="col">',
+    [escape("<td>")]: '<td class="ons-table__cell">',
+  });
+
+  return function htmlContentFilter(htmlContent) {
+    return htmlFixer(htmlContent);
+  };
+}

--- a/src/rendering/filters/htmlContentFilter.spec.js
+++ b/src/rendering/filters/htmlContentFilter.spec.js
@@ -1,0 +1,120 @@
+import createHtmlContentFilter from "./htmlContentFilter.js";
+
+describe("createHtmlContentFilter(site, data)", () => {
+  const site = {
+    baseUrl: "/en/",
+    absoluteBaseUrl: "https://localhost/",
+    craftBaseUrl: "https://craft.localhost/",
+  };
+
+  const htmlContentFilter = createHtmlContentFilter({ site });
+
+  describe("htmlContentFilter(htmlContent)", () => {
+    it.each([
+      [ `<a href="https://craft.localhost/cookies">Cookies</a>`, `<a href="/en/cookies">Cookies</a>` ],
+      [ `<a class="foo" aria-label="Cookies page" href="https://craft.localhost/cookies">Cookies</a>`, `<a href="/en/cookies" class="foo" aria-label="Cookies page">Cookies</a>` ],
+    ])("substitutes craft base url with the site base url in '%s'", (source, expectedString) => {
+      const string = htmlContentFilter(source);
+
+      expect(string).toBe(expectedString);
+    });
+
+    it.each([
+      [ `<a href="/@root/cookies">Cookies</a>`, `<a href="/en/cookies">Cookies</a>` ],
+      [ `<a class="foo" href="/@root/cookies" aria-label="Cookies page">Cookies</a>`, `<a href="/en/cookies" class="foo" aria-label="Cookies page">Cookies</a>` ],
+    ])("substitutes '/@root/' with the site base url in '%s'", (source, expectedString) => {
+      const string = htmlContentFilter(source);
+
+      expect(string).toBe(expectedString);
+    });
+
+    it("decorates `<a>` elements when their `target` is '_blank'", () => {
+      const string = htmlContentFilter(`<a class="foo" href="/@root/cookies" target="_blank">Cookies page</a>`);
+
+      expect(string).toBe(`<a href="/en/cookies" class="ons-external-link foo" target="_blank" rel="noopener">
+          <span class="ons-external-link__text">Cookies page</span><span class="ons-external-link__icon">&nbsp;<svg class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+            <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
+            <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
+          </svg></span><span class="ons-external-link__new-window-description ons-u-vh"> (opens in a new tab)</span></a>`);
+    });
+
+    it("does not decorate `<a>` elements when their `target` is '_self'", () => {
+      const string = htmlContentFilter(`<a class="foo" href="/@root/cookies" target="_self">Cookies page</a>`);
+
+      expect(string).toBe(`<a href="/en/cookies" class="foo" target="_self">Cookies page</a>`);
+    });
+
+    it("decorates `<table>` elements with the `ons-table` and `ons-table--scrollable` classes", () => {
+      const string = htmlContentFilter(`<table>`);
+
+      expect(string).toBe(`<table class="ons-table ons-table--scrollable">`);
+    });
+
+    it("decorates `<thead>` elements with the `ons-table__head` class", () => {
+      const string = htmlContentFilter(`<thead>`);
+
+      expect(string).toBe(`<thead class="ons-table__head">`);
+    });
+
+    it("decorates `<tbody>` elements with the `ons-table__body` class", () => {
+      const string = htmlContentFilter(`<tbody>`);
+
+      expect(string).toBe(`<tbody class="ons-table__body">`);
+    });
+
+    it("decorates `<tr>` elements with the `ons-table__row` class", () => {
+      const string = htmlContentFilter(`<tr>`);
+
+      expect(string).toBe(`<tr class="ons-table__row">`);
+    });
+
+    it("decorates `<th>` elements with the `ons-table__header` class and with column scope", () => {
+      const string = htmlContentFilter(`<th>`);
+
+      expect(string).toBe(`<th class="ons-table__header" scope="col">`);
+    });
+
+    it("decorates `<td>` elements with the `ons-table__cell` class", () => {
+      const string = htmlContentFilter(`<td>`);
+
+      expect(string).toBe(`<td class="ons-table__cell">`);
+    });
+  });
+
+  const htmlContentFilterWithCmsSource = createHtmlContentFilter({
+    site,
+    cms: {
+      getEntryById: (id) => ({ url: `/en/${id}` }),
+    },
+  });
+
+  describe("htmlContentFilter(htmlContent) with 'cms' source", () => {
+    it.each([
+      "http://localhost:3000/external-resource/42",
+      "http://localhost/external-resource/42",
+      "http://localhost/en/external-resource/42",
+      "http://en.localhost/external-resource/42",
+
+      "https://localhost:3000/external-resource/42",
+      "https://localhost/external-resource/42",
+      "https://localhost/en/external-resource/42",
+      "https://en.localhost/external-resource/42",
+
+      "//en/external-resource/42",
+      "//external-resource/42",
+
+      "/en/external-resource/42",
+      "/external-resource/42",
+    ])("resolves external urls of the format %s", (externalUrl) => {
+      const string = htmlContentFilterWithCmsSource(`<a href="${externalUrl}">Some external resource</a>`);
+      
+      expect(string).toBe(`<a href="/en/42">Some external resource</a>`);
+    });
+
+    it("resolves external urls of the format and maintains other attributes", () => {
+      const string = htmlContentFilterWithCmsSource(`<a class="foo" href="http://localhost:3000/external-resource/42">Some external resource</a>`);
+      
+      expect(string).toBe(`<a href="/en/42" class="foo">Some external resource</a>`);
+    });
+  });
+});


### PR DESCRIPTION
Previously some of this functionality has been applied by websites as a post-processing step just before the rendered pages is written to disk. This PR moves this logic into the static website generator so that it can be reused across multiple websites and automatically decorates external links.

Resolves #21 

## Usage example

```nunjucks
{{ '<a href="#" target="_blank">Some external link</a>, <a href="#">Some internal link</a>' | htmlContent | safe }}
```

## Notes

Links are considered external when:
- They start with a `/` or `//`.
- They start with the configured `site.baseUrl` or `site.absoluteBaseUrl` or `site.craftBaseUrl`.
- When the `target` attribute is `_blank`.

## Breaking change

This is a breaking change since excess logic will need to be removed from the `postprocessPageOutput` hook of existing websites.