### PR TITLE
Improve internal url detection

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -71,6 +71,8 @@ The following custom filters have been defined for use in templates:
 
 - `htmlContent` - Corrects internal URLs and decorates elements with ONS design system classes. This is useful for blobs of HTML content (eg. that from a WYSIWYG field). eg. `block.text | htmlContent | safe`.
 
+- `isInternalUrl(url)` - Returns `true` when an internal URL is provided; otherwise, returns `false`.
+
 - `itemsList_from_navigation` - Produces an array of items for use with ONS design system navigation components and lists. This uses the `navigationTitle`, `title` and `url` of provided entries to resolve navigation items.
 
 - `localize(context = "main")` - Allows strings to be automatically localized when a localized string is defined; eg. `"Table of contents" | localize`. A language context can be provided for situations where there would be ambiguity, eg. `"Add" | localize("maths")`.

--- a/src/helpers/getInternalUrlRegex.js
+++ b/src/helpers/getInternalUrlRegex.js
@@ -1,0 +1,12 @@
+import escape from "./escapeStringForRegExp.js";
+
+export default function getInternalUrlRegex(site) {
+  const patterns = [
+    escape("/"),
+    escape("#"),
+    escape(site.baseUrl ?? "").replace(/\\[/]$/, "($|[/])"),
+    escape(site.absoluteBaseUrl ?? "").replace(/\\[/]$/, "($|[/])"),
+    escape(site.craftBaseUrl ?? "").replace(/\\[/]$/, "($|[/])"),
+  ];
+  return new RegExp(`^(${patterns.filter(url => url !== "").join("|")})`);
+}

--- a/src/helpers/getInternalUrlRegex.spec.js
+++ b/src/helpers/getInternalUrlRegex.spec.js
@@ -1,0 +1,49 @@
+import getInternalUrlRegex from "./getInternalUrlRegex.js";
+
+describe("getInternalUrlRegex(site)", () => {
+  const site = {
+    baseUrl: "https://localhost:3000/",
+    absoluteBaseUrl: "https://localhost:3012/",
+    craftBaseUrl: "https://localhost:3024/",
+  };
+
+  const internalUrlRegex = getInternalUrlRegex(site);
+
+  it.each([
+    "/",
+    "/cookies",
+    "#",
+    "#cookies",
+    "https://localhost:3000",
+    "https://localhost:3000/",
+    "https://localhost:3000/cookies",
+    "https://localhost:3012",
+    "https://localhost:3012/",
+    "https://localhost:3012/cookies",
+    "https://localhost:3024",
+    "https://localhost:3024/",
+    "https://localhost:3024/cookies",
+  ])("returns a regular expression which matches internal urls (%s)", (url) => {
+    const isInternalUrl = internalUrlRegex.test(url);
+
+    expect(isInternalUrl).toBe(true);
+  });
+
+  it.each([
+    "https://localhost:5000#",
+    "https://localhost:5000#cookies",
+    "https://localhost:5000",
+    "https://localhost:5000/",
+    "https://localhost:5000/cookies",
+    "https://localhost:5012",
+    "https://localhost:5012/",
+    "https://localhost:5012/cookies",
+    "https://localhost:5024",
+    "https://localhost:5024/",
+    "https://localhost:5024/cookies",
+  ])("returns a regular expression which does not match external urls (%s)", (url) => {
+    const isInternalUrl = internalUrlRegex.test(url);
+
+    expect(isInternalUrl).toBe(false);
+  });
+});

--- a/src/rendering/createRenderer.js
+++ b/src/rendering/createRenderer.js
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 import nunjucks from "nunjucks";
 
 import createHtmlContentFilter from "./filters/htmlContentFilter.js";
+import createIsInternalUrlFilter from "./filters/isInternalUrlFilter.js";
 import createLocalizeFilter from "./filters/localizeFilter.js";
 import dateFilter from "./filters/dateFilter.js";
 import itemsList_from_navigationFilter from "./filters/itemsList_from_navigationFilter.js";
@@ -36,6 +37,7 @@ export default async function createRenderer(data, setupNunjucks = null) {
 
   nunjucksEnvironment.addFilter("date", dateFilter);
   nunjucksEnvironment.addFilter("htmlContent", createHtmlContentFilter(data));
+  nunjucksEnvironment.addFilter("isInternalUrl", createIsInternalUrlFilter(data));
   nunjucksEnvironment.addFilter("itemsList_from_navigation", itemsList_from_navigationFilter);
   nunjucksEnvironment.addFilter("itemsList_from_navigationItems", itemsList_from_navigationItemsFilter);
   nunjucksEnvironment.addFilter("localize", createLocalizeFilter(data.site, data.stringsByLanguage));

--- a/src/rendering/createRenderer.spec.js
+++ b/src/rendering/createRenderer.spec.js
@@ -109,6 +109,14 @@ describe("createRenderer()", () => {
       .not.toThrow();
   });
 
+  it("adds the custom 'isInternalUrl' filter", async () => {
+    const renderer = await createRenderer({ site });
+
+    await expect(renderer.renderString("{{ 'https://localhost:3000/' | isInternalUrl }}"))
+      .resolves
+      .not.toThrow();
+  });
+
   it("adds the custom 'itemsList_from_navigation' filter", async () => {
     const renderer = await createRenderer({ site });
 

--- a/src/rendering/filters/htmlContentFilter.js
+++ b/src/rendering/filters/htmlContentFilter.js
@@ -5,6 +5,7 @@ import resolveUrl from "../../helpers/resolveUrl.js";
 export default function createHtmlContentFilter(data) {
   const internalUrls = [
     "/",
+    "#",
     data.site.baseUrl ?? "",
     data.site.absoluteBaseUrl ?? "",
     data.site.craftBaseUrl ?? "",

--- a/src/rendering/filters/htmlContentFilter.js
+++ b/src/rendering/filters/htmlContentFilter.js
@@ -1,17 +1,10 @@
 import createStringReplacer from "../../helpers/createStringReplacer.js";
 import escape from "../../helpers/escapeStringForRegExp.js";
+import getInternalUrlRegex from "../../helpers/getInternalUrlRegex.js";
 import resolveUrl from "../../helpers/resolveUrl.js";
 
 export default function createHtmlContentFilter(data) {
-  const internalUrls = [
-    "/",
-    "#",
-    data.site.baseUrl ?? "",
-    data.site.absoluteBaseUrl ?? "",
-    data.site.craftBaseUrl ?? "",
-  ].filter(url => url !== "");
-
-  const internalUrlPattern = new RegExp(`^(${internalUrls.map(escape).join("|")})`);
+  const internalUrlRegex = getInternalUrlRegex(data.site);
 
   const htmlFixer = createStringReplacer({
     // Process links.
@@ -19,7 +12,7 @@ export default function createHtmlContentFilter(data) {
       const href = resolveUrl(groups.linkAttributes.match(/href="([^"]+)"/)?.[1], data);
       let target = groups.linkAttributes.match(/target="([^"]+)"/)?.[1];
 
-      const isInternalLink = internalUrlPattern.test(href);
+      const isInternalLink = internalUrlRegex.test(href);
       if (!isInternalLink && !target) {
         target = "_blank";
       }

--- a/src/rendering/filters/htmlContentFilter.spec.js
+++ b/src/rendering/filters/htmlContentFilter.spec.js
@@ -28,6 +28,16 @@ describe("createHtmlContentFilter(site, data)", () => {
       expect(string).toBe(expectedString);
     });
 
+    it("decorates `<a>` elements when non-internal links", () => {
+      const string = htmlContentFilter(`<a class="foo" href="https://external.localhost:1234/cookies" target="_blank">Some external cookies page</a>`);
+
+      expect(string).toBe(`<a href="https://external.localhost:1234/cookies" class="ons-external-link foo" target="_blank" rel="noopener">
+          <span class="ons-external-link__text">Some external cookies page</span><span class="ons-external-link__icon">&nbsp;<svg class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+            <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
+            <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
+          </svg></span><span class="ons-external-link__new-window-description ons-u-vh"> (opens in a new tab)</span></a>`);
+    });
+
     it("decorates `<a>` elements when their `target` is '_blank'", () => {
       const string = htmlContentFilter(`<a class="foo" href="/@root/cookies" target="_blank">Cookies page</a>`);
 

--- a/src/rendering/filters/htmlContentFilter.spec.js
+++ b/src/rendering/filters/htmlContentFilter.spec.js
@@ -1,6 +1,6 @@
 import createHtmlContentFilter from "./htmlContentFilter.js";
 
-describe("createHtmlContentFilter(site, data)", () => {
+describe("createHtmlContentFilter(site)", () => {
   const site = {
     baseUrl: "/en/",
     absoluteBaseUrl: "https://localhost/",

--- a/src/rendering/filters/htmlContentFilter.spec.js
+++ b/src/rendering/filters/htmlContentFilter.spec.js
@@ -54,6 +54,12 @@ describe("createHtmlContentFilter(site, data)", () => {
       expect(string).toBe(`<a href="/en/cookies" class="foo" target="_self">Cookies page</a>`);
     });
 
+    it("does not decorate `<a>` internal anchor links", () => {
+      const string = htmlContentFilter(`<a class="foo" href="#feedback">Leave feedback</a>`);
+
+      expect(string).toBe(`<a href="#feedback" class="foo">Leave feedback</a>`);
+    });
+
     it("decorates `<table>` elements with the `ons-table` and `ons-table--scrollable` classes", () => {
       const string = htmlContentFilter(`<table>`);
 

--- a/src/rendering/filters/isInternalUrlFilter.js
+++ b/src/rendering/filters/isInternalUrlFilter.js
@@ -1,0 +1,9 @@
+import getInternalUrlRegex from "../../helpers/getInternalUrlRegex.js";
+
+export default function createIsInternalUrlFilter(data) {
+  const internalUrlRegex = getInternalUrlRegex(data.site);
+
+  return function isInternalUrlFilter(url) {
+    return internalUrlRegex.test(url);
+  };
+}

--- a/src/rendering/filters/isInternalUrlFilter.spec.js
+++ b/src/rendering/filters/isInternalUrlFilter.spec.js
@@ -1,0 +1,34 @@
+import createIsInternalUrlFilter from "./isInternalUrlFilter.js";
+
+describe("createIsInternalUrlFilter(site)", () => {
+  const site = {
+    baseUrl: "/en/",
+    absoluteBaseUrl: "https://localhost/",
+    craftBaseUrl: "https://craft.localhost/",
+  };
+
+  const isInternalUrlFilter = createIsInternalUrlFilter({ site });
+
+  describe("isInternalUrlFilter(url)", () => {
+    it.each([
+      "/",
+      "#",
+      "/en/",
+      "https://localhost/",
+      "https://craft.localhost/",
+    ])("returns true for internal urls (%s)", (url) => {
+      const isInternalUrl = isInternalUrlFilter(url);
+
+      expect(isInternalUrl).toBe(true);
+    });
+
+    it.each([
+      "https://localhost:5000/",
+      "https://craft.localhost:5000/",
+    ])("returns false for external urls (%s)", (url) => {
+      const isInternalUrl = isInternalUrlFilter(url);
+
+      expect(isInternalUrl).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
- Fix issue where internal links of the form `#cookies` were being treated as external links.
- Move internal link regular expression into its own helper function for reuse elsewhere.
- Add `isInternalUrl(url)` filter for use in Nunjucks templates.