### PR TITLE
Replace site configuration `templatesPath` with `templateSearchPaths` for more flexibility.

### DIFF
--- a/docs/project-sites-configuration.md
+++ b/docs/project-sites-configuration.md
@@ -17,7 +17,7 @@ The following properties are required for each site:
 
 - `sources` (Array\<[Source](#content-sources)\>) - Configures content sources for the site.
 
-- `templatesPath` (String) - Path to the templates directory for this site. Defaults to "templates" directory in root of project.
+- `templateSearchPaths` (Array\<String\>) - Template search paths for this site. Defaults to "templates" directory in root of project.
 
 These can typically be setup with environment variables as follows:
 

--- a/src/Generator.js
+++ b/src/Generator.js
@@ -27,7 +27,9 @@ export default class Generator {
 
     try {
       const processedSites = Object.fromEntries(await Promise.all(this.sites.map(async site => {
-        site.templatesPath = site.templatesPath ?? this.defaultTemplatesPath;
+        if (!site.templateSearchPaths || site.templateSearchPaths.length === 0) {
+          site.templateSearchPaths = [ this.defaultTemplatesPath ];
+        }
 
         logger.stage(`Fetching data for site "${site.name}"...`);
         const data = await fetchSiteData(site, this.sitesByName);

--- a/src/Generator.spec.js
+++ b/src/Generator.spec.js
@@ -50,7 +50,7 @@ function createExampleOptions(options = {}) {
         baseUrl: "/en/",
         absoluteBaseUrl: "https://localhost:1234/en/",
         sources: FAKE_CONTENT_SOURCES,
-        templatesPath: "tests/examples/templates",
+        templateSearchPaths: [ "tests/examples/templates" ],
         hooks,
       },
       {
@@ -59,7 +59,7 @@ function createExampleOptions(options = {}) {
         baseUrl: "/cy/",
         absoluteBaseUrl: "https://localhost:1234/cy/",
         sources: FAKE_CONTENT_SOURCES,
-        templatesPath: "tests/examples/templates",
+        templateSearchPaths: [ "tests/examples/templates" ],
         hooks,
       },
     ],

--- a/src/rendering/createRenderer.js
+++ b/src/rendering/createRenderer.js
@@ -26,7 +26,7 @@ nunjucks.configure(null, {
 });
 
 export default async function createRenderer(data, setupNunjucks = null) {
-  const searchPaths = [ data.site.templatesPath, `${designSystemPath}`, `${designSystemPath}/src` ];
+  const searchPaths = [ ...data.site.templateSearchPaths, `${designSystemPath}`, `${designSystemPath}/src` ];
 
   const nunjucksLoader = new nunjucks.FileSystemLoader(searchPaths);
   const nunjucksEnvironment = new nunjucks.Environment(nunjucksLoader);

--- a/src/rendering/createRenderer.spec.js
+++ b/src/rendering/createRenderer.spec.js
@@ -2,7 +2,7 @@ import createRenderer from "./createRenderer.js";
 
 const site = {
   name: "en",
-  templatesPath: "tests/examples/templates",
+  templateSearchPaths: [ "tests/examples/templates" ],
 };
 
 describe("createRenderer()", () => {
@@ -185,7 +185,7 @@ describe("createRenderer()", () => {
   });
 
   describe("async renderer.render(page, context)", () => {
-    it("resolves page templates from the given templates directory", async () => {
+    it("resolves page templates from the given template search paths", async () => {
       const renderer = await createRenderer({ site });
   
       const examplePage = {


### PR DESCRIPTION
It is useful to have multiple search paths in the following scenarios:
- Searching for templates in component directories.
- Searching for templates within a node module.

## "breaking" change
In theory this is a breaking change but since none of the existing websites explicitly set the `templatesPath` configuration it does not actually break them.