### PR TITLE
Enhance `uniqueId` filter so that counting can restart in new scopes.

### DIFF
--- a/src/rendering/createRenderer.js
+++ b/src/rendering/createRenderer.js
@@ -4,11 +4,11 @@ import nunjucks from "nunjucks";
 import createHtmlContentFilter from "./filters/htmlContentFilter.js";
 import createIsInternalUrlFilter from "./filters/isInternalUrlFilter.js";
 import createLocalizeFilter from "./filters/localizeFilter.js";
+import createUniqueIdFilter from "./filters/uniqueIdFilter.js";
 import dateFilter from "./filters/dateFilter.js";
 import itemsList_from_navigationFilter from "./filters/itemsList_from_navigationFilter.js";
 import itemsList_from_navigationItemsFilter from "./filters/itemsList_from_navigationItemsFilter.js";
 import setPropertyFilter from "./filters/setPropertyFilter.js";
-import uniqueIdFilter from "./filters/uniqueIdFilter.js";
 
 const designSystemPath = `${ process.cwd() }/node_modules/@ons/design-system`;
 const designSystemCdnBaseUrl = "https://cdn.ons.gov.uk/sdc/design-system/";
@@ -42,7 +42,7 @@ export default async function createRenderer(data, setupNunjucks = null) {
   nunjucksEnvironment.addFilter("itemsList_from_navigationItems", itemsList_from_navigationItemsFilter);
   nunjucksEnvironment.addFilter("localize", createLocalizeFilter(data.site, data.stringsByLanguage));
   nunjucksEnvironment.addFilter("setProperty", setPropertyFilter);
-  nunjucksEnvironment.addFilter("uniqueId", uniqueIdFilter);
+  nunjucksEnvironment.addFilter("uniqueId", createUniqueIdFilter());
 
   setupNunjucks?.call(null, { nunjucksEnvironment });
 

--- a/src/rendering/filters/uniqueIdFilter.js
+++ b/src/rendering/filters/uniqueIdFilter.js
@@ -1,5 +1,24 @@
-let nextId = 1;
+const DEFAULT_OPTIONS = {
+  scope: "default",
+  suffix: ".id",
+  skipFirst: false,
+};
 
-export default function uniqueIdFilter(base) {
-  return `${!!base ? base : ""}.id.${nextId++}`;
+export default function createUniqueIdFilter(data) {
+  const counters = new Map();
+
+  return function uniqueIdFilter(base, options = null) {
+    base = !!base ? base : "";
+    options = Object.assign({}, DEFAULT_OPTIONS, options);
+
+    const key = `${options.scope}/${base}`;
+    const counter = (counters.get(key) ?? 0) + 1;
+    counters.set(key, counter);
+
+    if (options.skipFirst && counter === 1 && base !== "") {
+      return base;
+    }
+
+    return `${base}${options.suffix ?? ""}.${counter}`;
+  }
 }

--- a/src/rendering/filters/uniqueIdFilter.spec.js
+++ b/src/rendering/filters/uniqueIdFilter.spec.js
@@ -1,22 +1,90 @@
-import uniqueIdFilter from "./uniqueIdFilter.js";
+import createUniqueIdFilter from "./uniqueIdFilter.js";
 
-describe("uniqueIdFilter(base)", () => {
-  it("returns a different id each time", () => {
-    const ids = new Set();
+describe("createUniqueIdFilter()", () => {
+  const uniqueIdFilter = createUniqueIdFilter();
 
-    ids.add(uniqueIdFilter("article"));
-    ids.add(uniqueIdFilter("article"));
-    ids.add(uniqueIdFilter("article"));
+  describe("uniqueIdFilter(base, { scope: 'default', suffix: '.id.', skipFirst: false }?)", () => {
+    it("returns a different id each time", () => {
+      const ids = new Set();
 
-    expect(ids.size).toBe(3);
-  });
+      ids.add(uniqueIdFilter("article"));
+      ids.add(uniqueIdFilter("article"));
+      ids.add(uniqueIdFilter("article"));
 
-  it.each([
-    [ "article", /^article\.id\.[0-9]+$/ ],
-    [ "example-element", /^example-element\.id\.[0-9]+$/],
-  ])("returns id with the expected format (%s, %s)", (base, expectedPattern) => {
-    const id = uniqueIdFilter(base);
+      expect(ids.size).toBe(3);
+    });
 
-    expect(id).toMatch(expectedPattern);
+    it.each([
+      [ "article", /^article\.id\.[0-9]+$/ ],
+      [ "example-element", /^example-element\.id\.[0-9]+$/],
+    ])("returns id with the expected format (%s, %s)", (base, expectedPattern) => {
+      const id = uniqueIdFilter(base);
+
+      expect(id).toMatch(expectedPattern);
+    });
+
+    it("uses given suffix for identifier", () => {
+      const id = uniqueIdFilter("article", { suffix: ".foo" });
+
+      expect(id).toMatch(/^article\.foo\.[0-9]+$/);
+    });
+
+    it("removes suffix when `suffix` is `null`", () => {
+      const id = uniqueIdFilter("article", { suffix: null });
+
+      expect(id).toMatch(/^article\.[0-9]+$/);
+    });
+
+    it("uses clean sequence of identifiers for each provided scope", () => {
+      const idsWithScope1 = [
+        uniqueIdFilter("article", {
+          scope: "https://example.com/some-page",
+        }),
+        uniqueIdFilter("article", {
+          scope: "https://example.com/some-page",
+        }),
+      ];
+      const idsWithScope2 = [
+        uniqueIdFilter("example-block", {
+          scope: "https://example.com/a-different-page",
+        }),
+        uniqueIdFilter("example-block", {
+          scope: "https://example.com/a-different-page",
+        }),
+      ];
+
+      expect(idsWithScope1).toEqual([ "article.id.1", "article.id.2" ]);
+      expect(idsWithScope2).toEqual([ "example-block.id.1", "example-block.id.2" ]);
+    });
+
+    it("omits id counter on first identifier when `skipFirst` is `true`", () => {
+      const idsWithScope = [
+        uniqueIdFilter("example", {
+          scope: "https://example.com/skip-first",
+          skipFirst: true,
+        }),
+        uniqueIdFilter("example", {
+          scope: "https://example.com/skip-first",
+          skipFirst: true,
+        }),
+      ];
+
+      expect(idsWithScope).toEqual([ "example", "example.id.2" ]);
+    });
+
+    it("does not omit id counter on first identifier when `base` is empty", () => {
+      const idsWithScope = [
+        uniqueIdFilter(null, {
+          scope: "https://example.com/skip-first",
+          skipFirst: true,
+        }),
+        uniqueIdFilter(null, {
+          scope: "https://example.com/skip-first",
+          skipFirst: true,
+        }),
+      ];
+
+      expect(idsWithScope).toEqual([ ".id.1", ".id.2" ]);
+    });
   });
 });


### PR DESCRIPTION
This PR adds the following options to the `uniqueId` filter:

- `scope` - A string that identifies a unique scope; for example, the URL of the page being rendered.
- `suffix` - A suffix to add to generated identifiers; the default is ".id". The suffix can be disabled by providing a value of `null`.
- `skipFirst` - Indicates whether the suffix/counter should be skipped for the first identifier.

## Usage examples
By default unique identifiers are incremented across pages, however, they can be generated within their own scope by providing the page's URL:
```nunjucks
{{ "example" | uniqueId({ scope: page.url }) }}
{# example.id.1, example.id.2, example.id.3 #}
```

A custom suffix can be provided to produce identifiers in a different namespace:
```nunjucks
{{ "example" | uniqueId({ scope: page.url, suffix: ".b" }) }}
{# example.b.1, example.b.2, example.b.3 #}
```

The following outputs a user-friendly instance ID (useful when it's unlikely that there will be multiple instances of a block on a page):
```nunjucks
{{ "example" | uniqueId({ scope: page.url, suffix: null, skipFirst: true }) }}
{# example, example.2, example.3 #}
```

## How to test
- Verify that unit tests pass