### PR TITLE
Emit `getPageByUri` function in site data.

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -44,6 +44,7 @@ The following globals are provided to templates by the generator:
   - `site.title` - **string** - Localized website title from `generalGlobals.siteTitle`.
 ---
   - `page` - **object** - The current page either from static content, CraftCMS content or procedurally generated content.
+  - `getPageByUri(uri: string): object|null` - **function** - Gets a page object or null with the given URI.
 ---
   - `cms.getEntryById(id: number): object|null` - **function** - Gets an entry or null with the given ID.
   - `cms.getCategoryById(id: number): object|null` - **function** - Gets a category or null with the given ID.

--- a/src/Generator.js
+++ b/src/Generator.js
@@ -42,12 +42,16 @@ export default class Generator {
   
         logger.stage(`Creating pages for site ${site.name}...`);
         let pages = await createPagesFromContentSources(site, data);
-      
+
+        logger.stage(`Indexing pages for site ${site.name}...`);
+        const pagesByUri = new Map(pages.map(item => [ item.uri, item ]));
+        data.getPageByUri = (uri) => pagesByUri.get(uri) ?? null;
+
         logger.step("Applying default transforms to pages...");
         addUrlAttributes({ pages, site });
         logger.step("Applying transforms to pages...");
         await site.hooks?.applyTransformsToPages?.call(null, { pages, site, data });
-      
+
         logger.step("Paginating listing pages...");
         pages = pages.map(paginate).flat();
 

--- a/src/Generator.spec.js
+++ b/src/Generator.spec.js
@@ -153,6 +153,25 @@ describe("Generator", () => {
       expect(hookCalledWithContext[0].data.stringsByLanguage).toEqual(options.stringsByLanguage);
     });
 
+    it("emits the function `getPageByUri` on the site data object", async () => {
+      let hookCalledWithContext = [];
+      const hooks = {
+        preprocessDataForSite: async (context) => {
+          hookCalledWithContext.push(context);
+        },
+      };
+
+      const options = createExampleOptions({ hooks });
+      const generator = new Generator(options);
+
+      await generator.generate("dist/test/generate");
+
+      const homePage = hookCalledWithContext[0].data.getPageByUri("");
+      expect(homePage.title).toEqual("Home page (en)");
+      const contactPage = hookCalledWithContext[0].data.getPageByUri("contact");
+      expect(contactPage.title).toEqual("Contact page (en)");
+    });
+
     it("calls hook `applyTransformsToPages` to transform page objects", async () => {
       let hookCalledWithContext = [];
       const hooks = {


### PR DESCRIPTION
This allows templates to access specific pages using a given URI:

```nunjucks
{% set homePage = getPageByUri("") %}
Title of the home page: {{ homePage.title }}
```