### PR TITLE
Use `moment.utc` constructor instead of `moment` constructor to avoid interference from device timezone.

### DIFF
--- a/src/rendering/filters/dateFilter.js
+++ b/src/rendering/filters/dateFilter.js
@@ -1,7 +1,7 @@
 import moment from "moment";
 
 export default function dateFilter(str, format, locale = "en-gb") {
-  const localMoment = moment(str);
+  const localMoment = moment.utc(str);
   localMoment.locale(locale);
   return localMoment.format(format);
 }


### PR DESCRIPTION
Currently the behaviour of the `date` filter varies based upon the device timezone which causes inconsistencies when performing snapshot testing on generated output.