### PR TITLE
Support nested strings directory structure.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "front-matter": "^4.0.2",
     "fs-extra": "^10.1.0",
+    "glob": "^8.0.3",
     "marked": "^4.0.17",
     "moment": "^2.29.3",
     "nunjucks": "^3.2.3"

--- a/src/helpers/loadStringsSync.js
+++ b/src/helpers/loadStringsSync.js
@@ -1,4 +1,6 @@
 import fs from "fs-extra";
+import glob from "glob";
+import path from "path";
 
 export default function loadStringsSync(stringsPath) {
   const strings = {};
@@ -19,6 +21,7 @@ function discoverAvailableLanguagesSync(stringsPath) {
 }
 
 function discoverStringFilesForLanguageSync(stringsPath, language) {
-  return (fs.readdirSync(`${stringsPath}/${language}`))
-    .filter(name => name.endsWith(".json"));
+  const basePath = `${stringsPath}/${language}`;
+  return glob.sync(`${basePath}/**/*.json`)
+    .map(absolutePath => path.relative(basePath, absolutePath));
 }

--- a/src/helpers/loadStringsSync.spec.js
+++ b/src/helpers/loadStringsSync.spec.js
@@ -6,22 +6,30 @@ describe("loadStringsSync(stringsPath)", () => {
 
     expect(strings).toEqual({
       en: {
-        main: {
+        "main": {
           "exampleWithKey": "Keys are good for situations where there are large volumes of text...",
           "exampleWithNullValue": null,
         },
+
+        "nested/directory/example": {
+          "exampleFromNestedDirectory": "An example string from a nested directory.",
+        }
       },
 
       cy: {
-        main: {
+        "main": {
           "exampleWithKey": "Mae allweddi yn dda ar gyfer sefyllfaoedd lle mae llawer iawn o destun...",
           "exampleWithNullValue": null,
         },
 
-        panel: {
+        "panel": {
           "Hide panel": "Cuddio'r panel",
           "Show panel": "Dangos panel",
         },
+
+        "nested/directory/example": {
+          "exampleFromNestedDirectory": "Llinyn enghreifftiol o gyfeiriadur nythu.",
+        }
       },
     });
   });

--- a/tests/examples/strings/cy/nested/directory/example.json
+++ b/tests/examples/strings/cy/nested/directory/example.json
@@ -1,0 +1,3 @@
+{
+  "exampleFromNestedDirectory": "Llinyn enghreifftiol o gyfeiriadur nythu."
+}

--- a/tests/examples/strings/en/nested/directory/example.json
+++ b/tests/examples/strings/en/nested/directory/example.json
@@ -1,0 +1,3 @@
+{
+  "exampleFromNestedDirectory": "An example string from a nested directory."
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,6 +772,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
@@ -1111,6 +1118,17 @@ glob@^7.1.3, glob@^7.1.4:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
 
 globals@^11.1.0:
   version "11.12.0"
@@ -1721,6 +1739,13 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.1.tgz#6c9dffcf9927ff2a31e74b5af11adf8b9604b022"
+  integrity sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 moment@^2.29.3:
   version "2.29.4"


### PR DESCRIPTION
Resolves #41 

This PR allows the following localisation logic to work as expected:
```nunjucks
{{ "String from the context of a specific component" | localize("components/my-component") }}
```

The strings can then be provided in the following directory structure:
```
/strings/en/components/my-component.json
/strings/cy/components/my-component.json
/strings/etc...
```