### PR TITLE
updated ons-svg-icon to ons-svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@ons/design-system": "x"
   },
   "devDependencies": {
-    "@ons/design-system": "^62.2.2",
+    "@ons/design-system": "^65.0.0",
     "jest": "^28.1.3"
   }
 }

--- a/src/rendering/createRenderer.spec.js
+++ b/src/rendering/createRenderer.spec.js
@@ -49,7 +49,7 @@ describe("createRenderer()", () => {
 
     await expect(renderer.renderString("{{ designSystemVersion }}"))
       .resolves
-      .toBe("62.2.2");
+      .toBe("65.0.0");
   });
 
   it("adds a global to get the design system cdn base URL", async () => {
@@ -65,7 +65,7 @@ describe("createRenderer()", () => {
 
     await expect(renderer.renderString("{{ designSystemCdnUrl }}"))
       .resolves
-      .toBe("https://cdn.ons.gov.uk/sdc/design-system/62.2.2");
+      .toBe("https://cdn.ons.gov.uk/sdc/design-system/65.0.0");
   });
 
   it("is able to load templates from the design system", async () => {

--- a/src/rendering/filters/htmlContentFilter.js
+++ b/src/rendering/filters/htmlContentFilter.js
@@ -21,7 +21,7 @@ export default function createHtmlContentFilter(data) {
         const otherAttributes = groups.linkAttributes.replace(/\s+(href|target|rel|class)="[^"]+"/g, "");
 
         return `<a href="${href}" class="ons-external-link ${classNames}" target="_blank" rel="noopener"${otherAttributes}>
-          <span class="ons-external-link__text">${groups.linkText}</span><span class="ons-external-link__icon">&nbsp;<svg class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+          <span class="ons-external-link__text">${groups.linkText}</span><span class="ons-external-link__icon">&nbsp;<svg class="ons-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
             <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
             <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
           </svg></span><span class="ons-external-link__new-window-description ons-u-vh"> (opens in a new tab)</span></a>&nbsp;`;

--- a/src/rendering/filters/htmlContentFilter.spec.js
+++ b/src/rendering/filters/htmlContentFilter.spec.js
@@ -32,7 +32,7 @@ describe("createHtmlContentFilter(site)", () => {
       const string = htmlContentFilter(`<a class="foo" href="https://external.localhost:1234/cookies" target="_blank">Some external cookies page</a>`);
 
       expect(string).toBe(`<a href="https://external.localhost:1234/cookies" class="ons-external-link foo" target="_blank" rel="noopener">
-          <span class="ons-external-link__text">Some external cookies page</span><span class="ons-external-link__icon">&nbsp;<svg class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+          <span class="ons-external-link__text">Some external cookies page</span><span class="ons-external-link__icon">&nbsp;<svg class="ons-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
             <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
             <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
           </svg></span><span class="ons-external-link__new-window-description ons-u-vh"> (opens in a new tab)</span></a>&nbsp;`);
@@ -42,7 +42,7 @@ describe("createHtmlContentFilter(site)", () => {
       const string = htmlContentFilter(`<a class="foo" href="/@root/cookies" target="_blank">Cookies page</a>`);
 
       expect(string).toBe(`<a href="/en/cookies" class="ons-external-link foo" target="_blank" rel="noopener">
-          <span class="ons-external-link__text">Cookies page</span><span class="ons-external-link__icon">&nbsp;<svg class="ons-svg-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
+          <span class="ons-external-link__text">Cookies page</span><span class="ons-external-link__icon">&nbsp;<svg class="ons-icon" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
             <path d="M13.5,9H13a.5.5,0,0,0-.5.5v3h-9v-9h3A.5.5,0,0,0,7,3V2.5A.5.5,0,0,0,6.5,2h-4a.5.5,0,0,0-.5.5v11a.5.5,0,0,0,.5.5h11a.5.5,0,0,0,.5-.5v-4A.5.5,0,0,0,13.5,9Z" transform="translate(-2 -1.99)" />
             <path d="M8.83,7.88a.51.51,0,0,0,.71,0l2.31-2.32,1.28,1.28A.51.51,0,0,0,14,6.49v-4a.52.52,0,0,0-.5-.5h-4A.51.51,0,0,0,9,2.52a.58.58,0,0,0,.14.33l1.28,1.28L8.12,6.46a.51.51,0,0,0,0,.71Z" transform="translate(-2 -1.99)" />
           </svg></span><span class="ons-external-link__new-window-description ons-u-vh"> (opens in a new tab)</span></a>&nbsp;`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,10 +533,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@ons/design-system@^53.1.0":
-  version "53.1.0"
-  resolved "https://registry.yarnpkg.com/@ons/design-system/-/design-system-53.1.0.tgz#25943fb6be572ef2b2344af2e6216c24ae10bea6"
-  integrity sha512-Dn5kTe/7okvPdbeBvZC/mieSJH0bMTo13svcWiySzFenFemysdkIRuM8Xx+HlAV0nPSB+qx+GXcs5yHB+gbWPQ==
+"@ons/design-system@^65.0.0":
+  version "65.0.0"
+  resolved "https://registry.yarnpkg.com/@ons/design-system/-/design-system-65.0.0.tgz#052057e6adb02ab1c66b8ffce3868021f8e6460c"
+  integrity sha512-5khkxMC4RSNUPlM/O4BaqZZB97ntOnDa3+2FPRBbqIp2g5FKeAfgD8zSgiBkUw6RPYBdu678YzYHwwrWA5P9TQ==
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.20"


### PR DESCRIPTION
**What is the context of this PR**

The ons-svg-icon class has been updated to ons-icon in the design system. We needed to manually update this class on the htmlContentFilter as we currently replace html with the relevant external-link html manually. 

**How to review**

Confirm that the only class changed in the ons-svg-icon and that the new class is correct. 