### PR TITLE
add styling class to markdown headings

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "fs-extra": "^10.1.0",
     "glob": "^8.0.3",
     "marked": "^4.0.17",
+    "marked-gfm-heading-id": "^3.0.8",
     "moment": "^2.29.3",
     "nunjucks": "^3.2.3"
   },

--- a/src/processors/markdown.js
+++ b/src/processors/markdown.js
@@ -1,4 +1,5 @@
 import { marked } from "marked";
+import { gfmHeadingId } from "marked-gfm-heading-id";
 
 import StaticProcessor from "./processor.js";
 
@@ -13,6 +14,7 @@ const defaultOptions = {
   xhtml: false
 };
 
+marked.use(gfmHeadingId(false));
 export default class MarkdownStaticProcessor extends StaticProcessor {
   constructor(options) {
     super();

--- a/src/rendering/filters/htmlContentFilter.js
+++ b/src/rendering/filters/htmlContentFilter.js
@@ -35,7 +35,8 @@ export default function createHtmlContentFilter(data) {
     // Decorate table elements with ONS design system classes.
     [escape("<table>")]: '<div class="ons-table-scrollable__content"><table class="ons-table ons-table--scrollable">',
     [escape("</table>")]: '</table></div>',
-    [escape("<h2>")]: '<h2 class="ons-u-fs-m">',
+    [escape("<h2>")]: '<h3 class="ons-u-fs-m">',
+    [escape("</h2>")]: '</h3>',
     [escape("<thead>")]: '<thead class="ons-table__head">',
     [escape("<tbody>")]: '<tbody class="ons-table__body">',
     [escape("<tr>")]: '<tr class="ons-table__row">',

--- a/src/rendering/filters/htmlContentFilter.js
+++ b/src/rendering/filters/htmlContentFilter.js
@@ -35,6 +35,7 @@ export default function createHtmlContentFilter(data) {
     // Decorate table elements with ONS design system classes.
     [escape("<table>")]: '<div class="ons-table-scrollable__content"><table class="ons-table ons-table--scrollable">',
     [escape("</table>")]: '</table></div>',
+    [escape("<h2>")]: '<h2 class="ons-u-fs-m">',
     [escape("<thead>")]: '<thead class="ons-table__head">',
     [escape("<tbody>")]: '<tbody class="ons-table__body">',
     [escape("<tr>")]: '<tr class="ons-table__row">',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,6 +1107,11 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
+github-slugger@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-2.0.0.tgz#52cf2f9279a21eb6c59dd385b410f0c0adda8f1a"
+  integrity sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==
+
 glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -1709,6 +1714,13 @@ makeerror@1.0.12:
   integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
   dependencies:
     tmpl "1.0.5"
+
+marked-gfm-heading-id@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/marked-gfm-heading-id/-/marked-gfm-heading-id-3.0.8.tgz#7d77f264181633b78c7fcb522b1df46783689a64"
+  integrity sha512-JDKp7tqU0QYHGz9xBWiZGfiCPNcvg0PvNvRr6XvRTgIg4S4etZxns7+ez+YtREU8iuQJC0V6vLTae9n8FH6gxQ==
+  dependencies:
+    github-slugger "^2.0.0"
 
 marked@^4.0.17:
   version "4.0.18"


### PR DESCRIPTION
## What is the context of this PR
This ticket removes the id element and adds a new styling class to the markdown headers. 

Since the markdown headings are set to h2 by default, It does not follow the heading levels in the service manual. This ticket adds a class to the default h2 tag so that the font size fits.

## How to review
check that the html content filter adds a styling class to the h2 element. We need to also check that the markdown processor does not include an Id to the heading
