### PR TITLE
Feature update markdown processor to allow captions

### DIFF
--- a/src/processors/markdown.js
+++ b/src/processors/markdown.js
@@ -1,6 +1,6 @@
 import { marked } from "marked";
 import { gfmHeadingId } from "marked-gfm-heading-id";
-
+import markedExtension from "./marked-extension.js";
 import StaticProcessor from "./processor.js";
 
 const defaultOptions = {
@@ -15,6 +15,7 @@ const defaultOptions = {
 };
 
 marked.use(gfmHeadingId(false));
+marked.use(markedExtension());
 export default class MarkdownStaticProcessor extends StaticProcessor {
   constructor(options) {
     super();

--- a/src/processors/marked-extension.js
+++ b/src/processors/marked-extension.js
@@ -1,0 +1,19 @@
+export default function markedExtension() {
+  let headingText;
+  return {
+    renderer: {
+      heading(text) {
+        headingText = text;
+        return ''; 
+      }, 
+      table(header, body){
+        const caption = headingText ? `<caption class="ons-table__caption ons-u-fs-m">${headingText}</caption>` : '';
+        return `<table>
+          ${caption}
+          <thead>${header}</thead>
+          <tbody>${body}</tbody>
+        </table>`;
+      }
+    }
+  };
+}

--- a/src/processors/marked-extension.js
+++ b/src/processors/marked-extension.js
@@ -1,13 +1,22 @@
+// This code defines a custom renderer that extends marked.js and overrides the table rendering method to include a <caption>. 
+// You can learn more about custom renderer here at https://marked.js.org/using_pro#renderer
 export default function markedExtension() {
+  // Declare the heading text so it can be used globally
   let headingText;
   return {
     renderer: {
+      // Custom renderer for headings
       heading(text) {
+        // Set the heading text
         headingText = text;
+      // Return an empty string to skip rendering the heading itself
         return ''; 
-      }, 
+      },       
+      // Custom renderer for tables
       table(header, body){
-        const caption = headingText ? `<caption class="ons-table__caption ons-u-fs-m">${headingText}</caption>` : '';
+        // Check if there is heading text so we can add a caption
+        const caption = headingText ? `<caption>${headingText}</caption>` : '';
+        // Construct the table element with the optional caption
         return `<table>
           ${caption}
           <thead>${header}</thead>

--- a/src/rendering/filters/htmlContentFilter.js
+++ b/src/rendering/filters/htmlContentFilter.js
@@ -35,8 +35,6 @@ export default function createHtmlContentFilter(data) {
     // Decorate table elements with ONS design system classes.
     [escape("<table>")]: '<div class="ons-table-scrollable__content"><table class="ons-table ons-table--scrollable">',
     [escape("</table>")]: '</table></div>',
-    [escape("<h2>")]: '<h3 class="ons-u-fs-m">',
-    [escape("</h2>")]: '</h3>',
     [escape("<thead>")]: '<thead class="ons-table__head">',
     [escape("<tbody>")]: '<tbody class="ons-table__body">',
     [escape("<tr>")]: '<tr class="ons-table__row">',

--- a/src/rendering/filters/htmlContentFilter.js
+++ b/src/rendering/filters/htmlContentFilter.js
@@ -35,6 +35,7 @@ export default function createHtmlContentFilter(data) {
     // Decorate table elements with ONS design system classes.
     [escape("<table>")]: '<div class="ons-table-scrollable__content"><table class="ons-table ons-table--scrollable">',
     [escape("</table>")]: '</table></div>',
+    [escape("<caption>")]: '<caption class="ons-table__caption ons-u-fs-m ons-u-mb-s ons-u-mt-l">',
     [escape("<thead>")]: '<thead class="ons-table__head">',
     [escape("<tbody>")]: '<tbody class="ons-table__body">',
     [escape("<tr>")]: '<tr class="ons-table__row">',


### PR DESCRIPTION
Added an extension for the marked.js library to allow captions on tables. It also prevents the heading from being rendered. 